### PR TITLE
chore: release version

### DIFF
--- a/app/Cargo.lock
+++ b/app/Cargo.lock
@@ -146,6 +146,7 @@ dependencies = [
  "egui_extras",
  "env_logger",
  "fast_morphology",
+ "fs_extra",
  "futures 0.3.31",
  "image",
  "once_cell",
@@ -1430,6 +1431,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fuchsia-zircon"

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -34,3 +34,6 @@ serde_bytes = "0.11.17"
 thiserror = "1.0"
 anyhow = "1.0"
 once_cell = "1.21.3"
+
+[build-dependencies]
+fs_extra = "1.3.0"

--- a/app/build.rs
+++ b/app/build.rs
@@ -1,14 +1,69 @@
+use fs_extra::dir;
 use std::fs;
 use std::path::PathBuf;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 fn main() {
     let profile = std::env::var("PROFILE").unwrap();
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+
+    let manifest_dir = PathBuf::from(manifest_dir);
     let target_dir = PathBuf::from(&manifest_dir).join("target").join(&profile);
 
+    copy_config(&manifest_dir, &target_dir).expect("Failed to copy config.toml");
+
+    let backend_dir = PathBuf::from(&manifest_dir).join("../backend");
+    for entry in fs::read_dir(&backend_dir).expect("Failed to read backend directory") {
+        let entry = entry.expect("Failed to read entry");
+
+        if entry.file_type().expect("Failed to get file type").is_dir() {
+            let service_dir = backend_dir.join(entry.file_name());
+            let target_service_dir = target_dir.join("services").join(entry.file_name());
+
+            copy_python_project(&service_dir, &target_service_dir)
+                .expect(&format!("Failed to copy {}", service_dir.display()));
+        }
+    }
+}
+
+fn copy_config(manifest_dir: &PathBuf, target_dir: &PathBuf) -> Result<()> {
     let src = PathBuf::from(&manifest_dir).join("config.toml");
     let dst = target_dir.join("config.toml");
 
-    fs::copy(&src, &dst).expect("Failed to copy config.toml");
+    fs::copy(&src, &dst)?;
     println!("cargo:rerun-if-changed=config.toml");
+
+    Ok(())
+}
+
+fn copy_python_project(src_dir: &PathBuf, target_dir: &PathBuf) -> Result<()> {
+    fs::create_dir_all(&target_dir)?;
+
+    fs::copy(
+        &src_dir.join("pyproject.toml"),
+        &target_dir.join("pyproject.toml"),
+    )?;
+
+    fs::copy(&src_dir.join("uv.lock"), &target_dir.join("uv.lock"))?;
+
+    dir::copy(
+        &src_dir.join("src"),
+        &target_dir,
+        &dir::CopyOptions::default()
+            .overwrite(true)
+            .copy_inside(true),
+    )?;
+
+    // TODO: hack
+    let _ = dir::copy(
+        &src_dir.join("LivePortrait"),
+        &target_dir,
+        &dir::CopyOptions::default()
+            .overwrite(true)
+            .copy_inside(true),
+    );
+
+    println!("cargo:rerun-if-changed={}", src_dir.display());
+    Ok(())
 }

--- a/app/src/ai_tools/launcher.rs
+++ b/app/src/ai_tools/launcher.rs
@@ -1,0 +1,127 @@
+use anyhow::Context;
+use futures::future::join_all;
+use std::{path::Path, process::Command};
+use tokio::process::Command as TokioCommand;
+
+const UV_INSTALLER_URL: &str = "https://github.com/astral-sh/uv/releases/download/0.8.24";
+const PYTHON_VERSION: &str = "3.11";
+
+pub async fn run() -> Result<(), anyhow::Error> {
+    install_uv()?;
+    install_python()?;
+
+    let exe_path = std::env::current_exe()?;
+    let exe_dir = exe_path.parent().unwrap();
+    let services_dir = exe_dir.join("services");
+
+    let mut handles = vec![];
+
+    for entry in std::fs::read_dir(services_dir)? {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() {
+            let handle = tokio::spawn(async move {
+                uv_sync(&entry.path()).await?;
+                uv_run_service(&entry.path()).await?;
+
+                Ok::<(), anyhow::Error>(())
+            });
+
+            handles.push(handle);
+        }
+    }
+
+    for handle in join_all(handles).await {
+        handle??; // first ? unwraps JoinError, second ? unwraps anyhow::Error
+    }
+
+    Ok(())
+}
+
+fn install_uv() -> Result<(), anyhow::Error> {
+    let mut cmd = Command::new("uv");
+    cmd.arg("--help");
+
+    let output = cmd
+        .output()
+        .with_context(|| "Failed to detect uv installation")?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let mut cmd = {
+        if cfg!(target_os = "windows") {
+            let mut cmd = Command::new("powershell");
+            cmd.args(&[
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-Command",
+                &format!("irm {UV_INSTALLER_URL}/uv-installer.ps1 | iex"),
+            ]);
+            cmd
+        } else {
+            let mut cmd = Command::new("sh");
+            cmd.args(&[
+                "-c",
+                &format!(
+                    "curl --proto '=https' --tlsv1.2 -LsSf {UV_INSTALLER_URL}/uv-installer.sh | sh"
+                ),
+            ]);
+            cmd
+        }
+    };
+
+    cmd.output().with_context(|| "Failed to install uv")?;
+
+    Ok(())
+}
+
+fn install_python() -> Result<(), anyhow::Error> {
+    let err = format!("Failed to run `uv install python {PYTHON_VERSION}`");
+
+    let status = Command::new("uv")
+        .args(&["python", "install", PYTHON_VERSION])
+        .status()
+        .with_context(|| err.clone())?;
+
+    if !status.success() {
+        anyhow::bail!(err);
+    }
+
+    Ok(())
+}
+
+async fn uv_sync(dir: &Path) -> Result<(), anyhow::Error> {
+    let err = format!("Failed to run `uv sync` in {}", dir.display());
+
+    let status = TokioCommand::new("uv")
+        .arg("sync")
+        .current_dir(dir)
+        .status()
+        .await
+        .with_context(|| err.clone())?;
+
+    if !status.success() {
+        anyhow::bail!(err);
+    }
+
+    Ok(())
+}
+
+async fn uv_run_service(dir: &Path) -> Result<(), anyhow::Error> {
+    let err = format!("Failed to run `uv run service` in {}", dir.display());
+
+    let status = TokioCommand::new("uv")
+        .args(&["run", "service"])
+        .current_dir(dir)
+        .status()
+        .await
+        .with_context(|| err.clone())?;
+
+    if !status.success() {
+        anyhow::bail!(err);
+    }
+
+    Ok(())
+}

--- a/app/src/ai_tools/mod.rs
+++ b/app/src/ai_tools/mod.rs
@@ -5,6 +5,7 @@ use crate::{config::Config, image_canvas::ImageCanvas, worker::ErrorChan};
 pub mod error;
 mod face_swap;
 mod inpaint;
+pub mod launcher;
 mod portrait;
 mod selection;
 mod transport;

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1,6 +1,8 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 #![allow(rustdoc::missing_crate_level_docs)]
 
+use std::process;
+
 use anyhow::{Context, anyhow};
 use eframe::egui;
 
@@ -11,7 +13,7 @@ mod image_canvas;
 mod msg_panel;
 mod worker;
 
-use ai_tools::ToolsPanel;
+use ai_tools::{ToolsPanel, launcher};
 use image_canvas::ImageCanvas;
 use once_cell::sync::Lazy;
 use tokio::runtime::Runtime;
@@ -35,6 +37,17 @@ fn main() -> anyhow::Result<()> {
         RUNTIME.block_on(futures::future::pending::<()>());
     });
 
+    let launcher_handle = if cfg!(not(debug_assertions)) {
+        Some(RUNTIME.spawn(async move {
+            if let Err(e) = launcher::run().await {
+                eprintln!("Launcher failed: {e}");
+                process::exit(1);
+            }
+        }))
+    } else {
+        None
+    };
+
     let options: eframe::NativeOptions = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
             .with_inner_size([1200.0, 800.0])
@@ -43,7 +56,7 @@ fn main() -> anyhow::Result<()> {
         ..Default::default()
     };
 
-    eframe::run_native(
+    let gui_result = eframe::run_native(
         "AI Image Editor",
         options,
         Box::new(|cc| {
@@ -51,7 +64,13 @@ fn main() -> anyhow::Result<()> {
             Ok(Box::new(ImageEditorApp::new(&config)))
         }),
     )
-    .map_err(|e| anyhow::anyhow!("Failed to run eframe application: {:?}", e))
+    .map_err(|e| anyhow::anyhow!("Failed to run eframe application: {:?}", e));
+
+    if let Some(handle) = launcher_handle {
+        handle.abort();
+    }
+
+    gui_result
 }
 
 struct ImageEditorApp {

--- a/backend/aibox-image-lib/pyproject.toml
+++ b/backend/aibox-image-lib/pyproject.toml
@@ -2,7 +2,6 @@
 name = "aibox-image-lib"
 version = "0.1.0"
 description = "Add your description here"
-readme = "README.md"
 requires-python = ">=3.9,<3.15"
 dependencies = [
     "msgpack>=1.1.1",


### PR DESCRIPTION
imo deduplicare i venv non e' fattibile.
e.g. su un servizio abbiamo una versione vecchia pinnata di torch (required) che usata in altri posti spacca i servizi.

not that bad, alla fine anche scaricando quel gb in piu' in confronto al peso dei modelli non dovrebbe fare molta differenza.

piccolo problema di questa pr, chiudendo l'app non vengono killati i processi dei services, che continuano a girare all'infinito.